### PR TITLE
Update OpenJDK Docker base image to fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8-26
+FROM registry.opensource.zalan.do/stups/openjdk:8-29
 
 MAINTAINER Zalando SE
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8u91-b14-1-22
+FROM registry.opensource.zalan.do/stups/openjdk:8-26
 
 MAINTAINER Zalando SE
 


### PR DESCRIPTION
A new pull request with the same changes as #39, but created after Zappr was set up.

This updates the base docker image to the latest version, which fixes several security issues.
Thanks to @hjacobs for the initial Pull request.