### PR TITLE
Bugfix/#42 add event status filter back in

### DIFF
--- a/src/main/java/org/zalando/tarbela/config/ProducerConfiguration.java
+++ b/src/main/java/org/zalando/tarbela/config/ProducerConfiguration.java
@@ -77,6 +77,7 @@ public class ProducerConfiguration {
                 producerConfigurations.getTokens().getAccessTokenUri()).getAccessTokens();
     }
 
+    //TODO: figure out how to test this
     private URI addEventFilterQueryParameter(final URI uri) {
         try {
             return new URIBuilder(uri).addParameter(QUERY_EVENT_STATUS_FILTER_NAME, QUERY_EVENT_STATUS_FILTER_VALUE)

--- a/src/main/java/org/zalando/tarbela/config/ProducerConfiguration.java
+++ b/src/main/java/org/zalando/tarbela/config/ProducerConfiguration.java
@@ -83,7 +83,7 @@ public class ProducerConfiguration {
             return new URIBuilder(uri).addParameter(QUERY_EVENT_STATUS_FILTER_NAME, QUERY_EVENT_STATUS_FILTER_VALUE)
                                       .build();
         } catch (URISyntaxException e) {
-            log.error("Failed to launch producer with event URI: " + uri);
+            log.error("Failed to construct producer URI with event filter from: " + uri);
             throw new IllegalStateException(e);
         }
     }


### PR DESCRIPTION
During #34 the query parameter addition for status = NEW was lost, this pull request adds it back in.

Fixes #42.