### PR TITLE
upgrade base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8-29
+FROM registry.opensource.zalan.do/stups/openjdk:8-cd40
 
 MAINTAINER Zalando SE
 


### PR DESCRIPTION
use the last available openjdk image with no CVEs